### PR TITLE
Prevent constant re-loading of fonts when fontsizechange event occurs.

### DIFF
--- a/Engine/source/gui/core/guiControl.cpp
+++ b/Engine/source/gui/core/guiControl.cpp
@@ -654,7 +654,8 @@ void GuiControl::applyProfileSettings()
    {
 	   mProfile->mFontSize = mControlFontSize;
 	   mProfile->mFont = NULL;
-	   mProfile->loadFont();
+      mProfile->loadFont();
+      mFontSizeChanged = false;
    }
 
    /// Update the render alpha for the control.
@@ -2034,6 +2035,7 @@ void GuiControl::resetProfileSettings()
 	   mProfile->mFontSize = mFontSizeCopy;
 	   mProfile->mFont = NULL;
 	   mProfile->loadFont();
+      mFontSizeChanged = false;
    }
 
    GFX->getDrawUtil()->clearBitmapModulation();   


### PR DESCRIPTION
mFontSizeChanged was never set to false.

This is related to #20, as it prevented the _System.Runtime.InteropServices.SEHException_ from occuring.

Pullrequested to master as Developement was out of date.
