### PR TITLE
Handle null-pointer in PreLoadAllLOD

### DIFF
--- a/Engine/source/T3D/shapeBase.cpp
+++ b/Engine/source/T3D/shapeBase.cpp
@@ -2430,13 +2430,15 @@ void ShapeBase::prepRenderImage( SceneRenderState *state )
 //Lod preloading
 void ShapeBase::PreLoadAllLOD(SceneRenderState *state)
 {
-	for (S32 i = mShapeInstance->getSmallestVisibleDL(); i >= 0; i-- )
-	{
-	mShapeInstance->setCurrentDetail( i );
-	mShapeInstance->animate();
-	prepBatchRender( state, -1 );
-	calcClassRenderData();
-	}
+   if (!mShapeInstance)
+      return;
+   for (S32 i = mShapeInstance->getSmallestVisibleDL(); i >= 0; i-- )
+   {
+	   mShapeInstance->setCurrentDetail( i );
+	   mShapeInstance->animate();
+	   prepBatchRender( state, -1 );
+	   calcClassRenderData();
+   }
 }
 //End Lod preloading
 


### PR DESCRIPTION
When you have a camera without a shape, then mShapeInstance will be null.

This commit adds a check for whether mShapeInstance is null before preloading LOD's, to prevent a crash with free-roaming cameras.
