### PR TITLE
Fix V3025

### DIFF
--- a/Templates/C#-Full/Winterleaf.Engine.Omni/Classes/LiveScripts/xmlOverrideData.cs
+++ b/Templates/C#-Full/Winterleaf.Engine.Omni/Classes/LiveScripts/xmlOverrideData.cs
@@ -220,7 +220,7 @@ namespace WinterLeaf.Engine.Classes.LiveScripts
                 foreach (CompilerError ce in errs)
                     {
                     lock (Omni.self.tick)
-                        Omni.self.Error(String.Format(">>csFactory::File {0} Line {1} Column {2} MSG {3} ", ce.FileName, ce.Line, ce.Column, ce.ErrorText, ce.FileName));
+                        Omni.self.Error(String.Format(">>csFactory::File {0} Line {1} Column {2} MSG {3} ", ce.FileName, ce.Line, ce.Column, ce.ErrorText));
                     }
                 return false;
                 }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'Format' function. Arguments not used: ce.FileName. Winterleaf.Engine xmlOverrideData.cs 223