### PR TITLE
Fix V3008

### DIFF
--- a/Templates/C#-Full/Winterleaf.Demo.Full/Models.User/GameCode/Client/Gui/OptionsDlg/OptRemapInputCtrl.cs
+++ b/Templates/C#-Full/Winterleaf.Demo.Full/Models.User/GameCode/Client/Gui/OptionsDlg/OptRemapInputCtrl.cs
@@ -68,7 +68,6 @@ namespace WinterLeaf.Demo.Full.Models.User.GameCode.Client.Gui.OptionsDlg
                 }
 
             string cmd = sGlobal["$RemapCmd[" + this["index"] + "]"];
-            cmd = sGlobal["$RemapName[" + this["index"] + "]"];
 
             // Grab the friendly display name for this action
             // which we'll use when prompting the user below.


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- The 'cmd' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 71, 70. Winterleaf.Demo.Full OptRemapInputCtrl.cs 71