### PR TITLE
Fix V3001

### DIFF
--- a/Templates/C#-Full/Winterleaf.Demo.Full/Models.User/GameCode/Tools/DecalEditor/gui/DecalEditorGui.cs
+++ b/Templates/C#-Full/Winterleaf.Demo.Full/Models.User/GameCode/Tools/DecalEditor/gui/DecalEditorGui.cs
@@ -1973,7 +1973,7 @@ namespace WinterLeaf.Demo.Full.Models.User.GameCode.Tools.DecalEditor.gui
                 // Same work to do as for the regular WorldEditor Inspector.
                 Inspector.onInspectorFieldModified(objectx, fieldName, arrayIndex, oldValue, newValue);
 
-                if (oldValue != newValue || oldValue != newValue)
+                if (oldValue != newValue)
                     this.setDirty(objectx);
             }
 


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- There are identical sub-expressions 'oldValue != newValue' to the left and to the right of the '||' operator. Winterleaf.Demo.Full DecalEditorGui.cs 1976