### PR TITLE
Fix V3088

### DIFF
--- a/Templates/C#-Full/Winterleaf.Demo.Full/Models.User/GameCode/Tools/ShapeEditor/gui/ShapeEdAnimWindow.ed.cs
+++ b/Templates/C#-Full/Winterleaf.Demo.Full/Models.User/GameCode/Tools/ShapeEditor/gui/ShapeEdAnimWindow.ed.cs
@@ -862,7 +862,7 @@ namespace WinterLeaf.Demo.Full.Models.User.GameCode.Tools.ShapeEditor.gui
             int frameCount = Util.getWord(ShapeEdSeqSlider["range"], 1).AsInt();
             int pos_x = Util.getWord(ShapeEdSeqSlider.getPosition().AsString(), 0).AsInt();
             int len_x = Util.getWord(ShapeEdSeqSlider.getExtent().AsString(), 0).AsInt() - width;
-            return pos_x + ((len_x*val/frameCount));
+            return pos_x + (len_x*val/frameCount);
         }
 
         // Set the in or out sequence limit


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- The expression was enclosed by parentheses twice: '(len_x*val/frameCount)'. One pair of parentheses is unnecessary or misprint is present. Winterleaf.Demo.Full ShapeEdAnimWindow.ed.cs 865