### PR TITLE
Fix V3008

### DIFF
--- a/Templates/C#-Full/Winterleaf.Demo.Full/Models.User/GameCode/Tools/EditorClasses/RSSNews/RSSFeedScript.ed.cs
+++ b/Templates/C#-Full/Winterleaf.Demo.Full/Models.User/GameCode/Tools/EditorClasses/RSSNews/RSSFeedScript.ed.cs
@@ -297,9 +297,7 @@ namespace WinterLeaf.Demo.Full.Models.User.GameCode.Tools.EditorClasses.RSSNews
             [ConsoleInteraction]
             public void initialize(string callback)
             {
-                RSSFeedObject RSSFeedObject = "RSSFeedObject";
-
-                RSSFeedObject = new ObjectCreator("TCPObject", "RSSFeedObject", typeof (RSSFeedObject)).Create();
+                RSSFeedObject RSSFeedObject = new ObjectCreator("TCPObject", "RSSFeedObject", typeof (RSSFeedObject)).Create();
                 RSSFeedObject["_callback"] = callback;
 
                 RSSFeedObject.connect(sGlobal["$RSSFeed::serverName"] + ":" + sGlobal["$RSSFeed::serverPort"]);


### PR DESCRIPTION
 Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- The 'RSSFeedObject' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 302, 300. Winterleaf.Demo.Full RSSFeedScript.ed.cs 302